### PR TITLE
Adding a configurable timeout for each uplink

### DIFF
--- a/lib/config_def.yaml
+++ b/lib/config_def.yaml
@@ -12,6 +12,10 @@ uplinks:
   npmjs:
     url: https://registry.npmjs.org/
 
+    # amount of time to wait for repository to respond before giving up
+    # and use the local cached copy
+    timeout: 3000
+
     # maximum time (in seconds) in which data is considered up to date
     #
     # default is 2 minutes, so server won't request the same data from

--- a/lib/up-storage.js
+++ b/lib/up-storage.js
@@ -32,6 +32,9 @@ function Storage(config, mainconfig) {
 	_setupProxy.call(this, this.url.hostname, config, mainconfig, this.url.protocol === 'https:')
 
 	this.config.url = this.config.url.replace(/\/$/, '')
+	if (isNaN(parseFloat(this.config.timeout)) || !isFinite(this.config.timeout)) {
+		this.config.timeout = 5000
+	}
 	return this
 }
 
@@ -105,6 +108,7 @@ Storage.prototype.request = function(options, cb) {
 		body: json,
 		ca: this.ca,
 		proxy: this.proxy,
+		timeout: this.config.timeout
 	}, function(err, res, body) {
 		var error
 		if (!err) {


### PR DESCRIPTION
I added a timeout config value for the uplinks.  Without this timeout I've found that the fallback to local cached copies of packages is much too slow, especially for packages with many dependencies (where the timeout applies to each dependency).  
