### PR TITLE
exit with appropriate status code

### DIFF
--- a/test/start.sh
+++ b/test/start.sh
@@ -5,5 +5,6 @@ PATH='../node_modules/.bin':$PATH
 TESTDIR=$(dirname $0)
 cd $TESTDIR
 mocha -R list --ui exports ./tests.js ./no_proxy.js
+TESTRES=$?
 cd $CWD
-
+exit $TESTRES


### PR DESCRIPTION
Correct test starter to return appropriate exit code

However yapm test run freaks out unnecessarily given that it's a test, but it's probably "expected behavior".
