### PR TITLE
Make 404 responses compatible with CouchDB API

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -64,7 +64,15 @@ module.exports = function(config_hash) {
 			if (err.status && err.status >= 400 && err.status < 600) {
 				if (calls == 1) {
 					res.status(err.status)
-					res.send({error: err.msg || err.message || 'unknown error'})
+					var body = {error: err.msg || err.message || 'unknown error'};
+
+					// Make 404 responses compliant with CouchDB REST API
+					if (err.status == 404) {
+						body.reason = body.error
+						body.error = 'not_found'
+					}
+
+					res.send(body)
 				}
 			} else {
 				Logger.logger.error({err: err}, 'unexpected error: @{!err.message}\n@{err.stack}')


### PR DESCRIPTION
The CouchDB REST API returns always `"error": "not_found"` in the body of a 404 response:
  http://couchdb-13.readthedocs.org/en/latest/api-basics/#http-status-codes

The npm client depends on the magic string 'not_found' as can be seen
in requestDone() in [npm-registry-client/lib/request.js](https://github.com/npm/npm/blob/ce662561ca0a7b154a7e6058a6a2428b49bd7266/node_modules/npm-registry-client/lib/request.js#L230).

Before this change, npm install of an unknown package was reporting
the Sinopia error string and a stack trace of npm:

```
npm http GET http://localhost:4873/does-not-exist
npm http 404 http://localhost:4873/does-not-exist
npm ERR! Error: no such package available : does-not-exist
npm ERR!     at RegClient.<anonymous> (/usr/local/lib/node_modules/npm/node_modules/npm-registry-client/lib/request.js:237:14)
npm ERR!     at Request.self.callback (/usr/local/lib/node_modules/npm/node_modules/request/request.js:123:22)
npm ERR!     at Request.EventEmitter.emit (events.js:98:17)
npm ERR!     at Request.<anonymous> (/usr/local/lib/node_modules/npm/node_modules/request/request.js:893:14)
npm ERR!     at Request.EventEmitter.emit (events.js:117:20)
npm ERR!     at IncomingMessage.<anonymous> (/usr/local/lib/node_modules/npm/node_modules/request/request.js:844:12)
npm ERR!     at IncomingMessage.EventEmitter.emit (events.js:117:20)
npm ERR!     at _stream_readable.js:920:16
npm ERR!     at process._tickCallback (node.js:415:13)
npm ERR! If you need help, you may report this *entire* log,
npm ERR! including the npm and node versions, at:
npm ERR!     <http://github.com/npm/npm/issues>
```

After this change, npm install of an unknown package returns a nice
error saying "the package is not in the npm registry, bug the author"

```
npm http GET http://localhost:4873/does-not-exist
npm http 404 http://localhost:4873/does-not-exist
npm ERR! 404 'does-not-exist' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it
npm ERR! 404
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, or http url, or git url.
```
