### PR TITLE
Fix support for old packages

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,7 +10,7 @@ module.exports.validate_name = function(name) {
 	if (
 		name.charAt(0) === '.' || // ".bin", etc.
 		name.charAt(0) === '-' || // "-" is reserved by couchdb
-		name.match(/[\/\s\+%:]/) ||
+		name.match(/[\\\/\s\+%:]/) ||
 		name === 'node_modules' ||
 		name === '__proto__' ||
 		name === 'package.json' ||

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -5,6 +5,7 @@ describe('Validate', function() {
 	it('good ones', function() {
 		assert(validate('sinopia'))
 		assert(validate('some.weird.package-zzz'))
+		assert(validate('old-package@0.1.2.tgz'))
 	})
 
 	it('uppercase', function() {
@@ -32,7 +33,6 @@ describe('Validate', function() {
 	})
 
 	it('other', function() {
-		assert(!validate('pkg@'))
 		assert(!validate('pk g'))
 		assert(!validate('pk\tg'))
 		assert(!validate('pk%20g'))


### PR DESCRIPTION
Old packages have name@version in the tarball name instead of name-version. Fixes #75
