### PR TITLE
Point to the new docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Now you can navigate to [http://localhost:4873/](http://localhost:4873/) where y
 
 ### Docker
 
-A Sinopia docker image [is available](https://index.docker.io/u/keyvanfatehi/docker-sinopia/)
+A Sinopia docker image [is available](https://registry.hub.docker.com/u/keyvanfatehi/sinopia/)
 
 ### Chef
 


### PR DESCRIPTION
### Differences
- bumps to the 0.9.0 release
- generates sinopia config on first run via custom script
- can now be built directly with a Dockerfile, no preliminary step
- it is an automated build on the docker index

this replaces the [old image](https://registry.hub.docker.com/u/keyvanfatehi/docker-sinopia/) -- the old image has also been updated to 0.9.0 but it is not an automated build and will no longer be updated. (i will remove it on next release if I can). ideally, docker will allow us to convert repos to automated build repos that once weren't.
