### PR TITLE
Filter falsey _npmUser values

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -368,7 +368,7 @@ Storage.prototype.search = function(startkey, options, callback) {
 							'dist-tags'   : {
 								latest: latest
 							},
-							maintainers   : data.versions[latest].maintainers || [data.versions[latest]._npmUser],
+							maintainers   : data.versions[latest].maintainers || [data.versions[latest]._npmUser].filter(Boolean),
 							readmeFilename: data.versions[latest].readmeFilename || '',
 							time          : {
 								modified: new Date(item.time).toISOString()


### PR DESCRIPTION
Some packages that were published with much older versions of npm (e.g., 1.0.x) don't have `maintainers` or `_npmUser` fields in their package.json files. This triggers a client-side error when doing `npm search` because the maintainers field will be `[null]` and the npm client attempts to read the `name` field on a null value.

This patch filters falsey `_npmUser` values, which prevents the client crash.
