### PR TITLE
LDAP Auth Support

### DIFF
--- a/lib/access-control-list.js
+++ b/lib/access-control-list.js
@@ -1,0 +1,110 @@
+var assert = require('assert')
+  , UError = require('./error').UserError
+  , utils = require('./utils')
+  , Logger = require('./logger')
+  , minimatch = require('minimatch')
+  , lodash = require('lodash')
+
+// [[a, [b, c]], d] -> [a, b, c, d]
+function flatten(array) {
+    var result = []
+    for (var i=0; i<array.length; i++) {
+        if (Array.isArray(array[i])) {
+            result.push.apply(result, flatten(array[i]))
+        } else {
+            result.push(array[i])
+        }
+    }
+    return result
+}
+
+function AccessControlList(packages, uplinks) {
+    var self = this
+    this.packages = packages
+    this.uplinks = uplinks
+    this.logger = Logger.logger.child({sub: 'local'})
+
+    this.allowed_actions = {}
+
+    this.users = {all:true, anonymous:true, 'undefined':true, owner:true, none:true}
+    this.uplinks = {}
+
+    function check_userlist(i, hash, action) {
+        self.allowed_actions[i][action] = hash[action]
+        if (self.allowed_actions[i][action] == null) self.allowed_actions[i][action] = []
+
+        // if it's a string, split it to array
+        if (typeof(self.allowed_actions[i][action]) === 'string') {
+            self.allowed_actions[i][action] = self.allowed_actions[i][action].split(/\s+/)
+        }
+
+        assert(
+            typeof(self.allowed_actions[i][action]) === 'object' &&
+            Array.isArray(self.allowed_actions[i][action])
+        , 'CONFIG: bad "'+i+'" package '+action+' description (array or string expected)')
+        self.allowed_actions[i][action] = flatten(self.allowed_actions[i][action])
+    }
+
+    for (var i in packages) {
+        this.allowed_actions[i] = {}
+        assert(
+            typeof(packages[i]) === 'object' &&
+            !Array.isArray(packages[i])
+        , 'CONFIG: bad "'+i+'" package description (object expected)')
+
+        check_userlist(i, packages[i], 'allow_access')
+        check_userlist(i, packages[i], 'allow_publish')
+        check_userlist(i, packages[i], 'proxy_access')
+        check_userlist(i, packages[i], 'proxy_publish')
+
+        // deprecated
+        check_userlist(i, packages[i], 'access')
+        check_userlist(i, packages[i], 'proxy')
+        check_userlist(i, packages[i], 'publish')
+    }
+
+    return this
+}
+
+
+AccessControlList.prototype.allow_action = function(package, username, groups, action) {
+  var self = this
+    , allowed_actions_for_package = self.get_allowed_actions_for_package(package, action)
+    , who = self.prepare_who(username, groups)
+  var matching = lodash.intersection(allowed_actions_for_package, who)
+  if (matching.length > 0) {
+    return matching
+  } else {
+    return false
+  }
+}
+
+AccessControlList.prototype.get_allowed_actions_for_package = function(package, setting) {
+    var self = this
+    for (var i in self.packages) {
+        if (minimatch.makeRe(i).exec(package)) {
+            return self.allowed_actions[i][setting]
+        }
+    }
+    return undefined
+}
+
+AccessControlList.prototype.prepare_who = function(username, groups) {
+    who = []
+    who = who.concat(groups)
+    who.push(username)
+    who.push('all')
+    return who
+}
+
+AccessControlList.prototype.has_authorization_for_package = function(username, groups, action, package, callback) {
+    allowed_by = this.allow_action(package, username, groups, action) || this.allow_action(package, username, groups, 'allow_' + action)
+    callback(null, allowed_by)
+}
+
+AccessControlList.prototype.has_authorization_for_uplink = function(username, groups, action, package, uplink, callback) {
+    allowed_by = this.allow_action(package, username, groups, action) || this.allow_action(package, username, groups, 'proxy_' + action)
+    callback(null, allowed_by)
+}
+
+module.exports = AccessControlList

--- a/lib/auth-ldap.js
+++ b/lib/auth-ldap.js
@@ -1,0 +1,67 @@
+var crypto = require('crypto')
+  , assert = require('assert')
+  , UError = require('./error').UserError
+  , utils = require('./utils')
+  , AuthenticatedUser = require('./authenticated-user')
+  , Logger = require('./logger')
+  , LdapAuth = require('ldapauth-fork')
+  , parseDN = require('ldapjs').parseDN
+
+function Auth(config, acl) {
+    if (!(this instanceof Auth)) return new Auth(config)
+    this.config = config
+    this.acl = acl
+    this.logger = Logger.logger.child({sub: 'ldap'})
+
+    // TODO: Set more defaults
+    this.config.groupNameAttribute = this.config.groupNameAttribute || 'cn'
+    this.ldap = new LdapAuth(this.config.client_options)
+
+    return this
+}
+
+//
+// Attempt to authenticate user against LDAP backend
+//
+Auth.prototype.authenticate = function(user, password, callback) {
+    var self = this
+        , authenticated_user
+
+    self.ldap.authenticate(user, password, function(err, ldap_user) {
+        if (err) {
+            // 'No such user' is reported via error
+            self.logger.warn({
+                user: user,
+                err: err,
+            }, 'LDAP error @{err}')
+            return callback()
+        }
+
+        if (ldap_user) {
+            var groups = []
+            for (var i = 0; i < ldap_user.memberOf.length; i++) {
+                groups.push("%" + parseDN(ldap_user.memberOf[i]).rdns[0][self.config.groupNameAttribute])
+            };
+            authenticated_user = new AuthenticatedUser(self.name, user, groups, self.acl)
+        }
+
+        callback(null, authenticated_user)
+    })
+}
+
+Auth.prototype.add_user = function(user, password, cb) {
+    var self = this
+
+    self.authenticate(user, password, function(authenticated_user) {
+        if (authenticated_user) {
+            return cb()
+        } else {
+            return cb(new UError({
+                status: 409,
+                message: 'registration is disabled',
+            }))
+        }
+    })
+}
+
+module.exports = Auth

--- a/lib/auth-local.js
+++ b/lib/auth-local.js
@@ -1,0 +1,90 @@
+var crypto = require('crypto')
+  , assert = require('assert')
+  , UError = require('./error').UserError
+  , utils = require('./utils')
+  , AuthenticatedUser = require('./authenticated-user')
+  , Logger = require('./logger')
+
+function Auth(config, acl, local_users, users_file) {
+    if (!(this instanceof Auth)) return new Auth(config)
+    var self = this
+    self.acl = acl
+    self.config = config
+
+    self.local_users = {}
+
+    self.logger = Logger.logger.child({sub: 'local'})
+
+    var check_user = function(arg) {
+        assert(arg !== 'all' || arg !== 'owner' || arg !== 'anonymous' || arg !== 'undefined' || arg !== 'none', 'CONFIG: reserved user/uplink name: ' + arg)
+        assert(!arg.match(/\s/), 'CONFIG: invalid user name: ' + arg)
+        assert(self.local_users[arg] == null, 'CONFIG: duplicate user/uplink name: ' + arg)
+        self.local_users[arg] = local_users[arg]
+    }
+
+    for (var i in local_users) check_user(i)
+
+    for (var i in self.local_users) {
+        assert(self.local_users[i].password, 'CONFIG: no password for user: ' + i)
+        assert(
+            typeof(self.local_users[i].password) === 'string' &&
+            self.local_users[i].password.match(/^[a-f0-9]{40}$/)
+        , 'CONFIG: wrong password format for user: ' + i + ', sha1 expected')
+    }
+
+    console.log('users_file', users_file);
+    if (users_file) {
+        self.HTPasswd = require('./htpasswd')(users_file)
+    }
+
+    return self
+}
+
+//
+// Attempt to authenticate user against local (config.yaml) users
+//
+Auth.prototype.authenticate = function(user, password, cb) {
+    var self = this
+    var authenticated_user
+
+    if (self.users != null && self.users[user] != null) {
+        // if user exists in self.users, verify password against it no matter what is in htpasswd
+        if (crypto.createHash('sha1').update(password).digest('hex') === self.users[user].password) {
+            authenticated_user = new AuthenticatedUser('local', user, [], self.acl)
+        }
+        return cb(null, authenticated_user);
+    }
+
+    if (!self.HTPasswd) return cb(null, false)
+    self.HTPasswd.reload(function() {
+        if (self.HTPasswd.verify(user, password)) {
+            authenticated_user = new AuthenticatedUser('local', user, [], self.acl)            
+        }
+        cb(null, authenticated_user)
+    })
+}
+
+Auth.prototype.add_user = function(user, password, cb) {
+    var self = this
+
+    self.authenticate(user, password, function(authenticated_user) {
+        if (authenticated_user) {
+            return cb()
+        } else {
+            if (self.HTPasswd) {
+                if (self.max_users || self.max_users == null) {
+                    var max_users = Number(self.max_users || Infinity)
+                    self.HTPasswd.add_user(user, password, max_users, cb)
+                }
+            } else {
+                return cb(new UError({
+                    status: 409,
+                    message: 'registration is disabled',
+                }))                
+            }
+        }
+    })
+}
+
+
+module.exports = Auth

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,0 +1,115 @@
+var async = require('async')
+  , assert = require('assert')
+  , UError = require('./error').UserError
+  , Ldap = require('./auth-ldap')
+  , Local = require('./auth-local')
+  , Path = require('path')
+  , utils = require('./utils')
+  , Logger = require('./logger')
+  , AccessControlList = require('./access-control-list')
+
+//
+// Implements Auth interface
+// (same for auth.js, auth-local.js, auth-ldap.js)
+//
+function Auth(config) {
+	if (!(this instanceof Auth)) return new Auth(config)
+
+	this.config = config
+
+    this.config.auth = this.config.auth || {'local': {type: 'local'}}
+
+    this.acl = new AccessControlList(config.packages, config.uplinks)
+
+	this.backends = []
+	for (var p in config.auth) {
+        var backend
+        if (config.auth[p].type === "ldap") {
+            backend = new Ldap(config.auth[p], this.acl)
+        } else if (config.auth[p].type === "local") {
+            var users_file
+            if (config.users_file) {
+                users_file = Path.resolve(
+                    Path.dirname(config.self_path),
+                    config.users_file
+                )
+            }
+
+            backend = new Local(config.auth[p], this.acl, config.users, users_file)
+        }
+        assert(!!backend, 'CONFIG: invalid auth type: ' + config.auth[p].type)
+		backend.name = p
+        this.backends.push(backend)
+	}
+	this.logger = Logger.logger.child()
+
+	return this
+}
+
+//
+// Authenticate {user}
+//
+// Attempt to authenticate with each backend until authenticated
+//
+Auth.prototype.authenticate = function(user, password, callback) {
+    var self = this
+
+    var check = function(backend, next) {
+        self.logger.info({
+            user: user,
+            backend: backend.name,
+        }, 'Attempting to authenticate user @{user} with backend @{backend}')
+        backend.authenticate(user, password, function(err, authenticated_user) {
+            if (authenticated_user) {
+                self.logger.info({
+                    user: authenticated_user.username,
+                    backend: authenticated_user.backend,
+                }, 'Authenticated user @{user} with backend @{backend}')
+                callback(null, authenticated_user)
+            } else if (err) {
+                callback(err)
+            } else {
+                next()
+            }
+        })
+    }
+
+    async.eachSeries(self.backends, check, function() {
+        self.logger.info({
+            user: user
+        }, 'Failed to authenticate user @{user}')
+        callback(null)
+    })
+}
+
+Auth.prototype.add_user = function(user, password, callback) {
+    var self = this
+
+    var check = function(backend, next) {
+        self.logger.info({
+            user: user,
+            backend: backend.name,
+        }, 'Attempting to add user @{user} with backend @{backend}')
+        backend.add_user(user, password, function(err) {
+            console.log('backend.add_user', err);
+            if (err) {
+                next()
+            } else {
+                callback()
+            }
+        })
+    }
+
+    async.eachSeries(self.backends, check, function() {
+        self.logger.info({
+            user: user
+        }, 'Failed to authenticate user @{user}')
+        callback(new UError({
+            status: 409,
+            message: 'registration is disabled',
+        }))
+    })
+}
+
+module.exports = Auth
+

--- a/lib/authenticated-user.js
+++ b/lib/authenticated-user.js
@@ -1,0 +1,67 @@
+var async = require('async')
+  , UError = require('./error').UserError
+  , Logger = require('./logger')
+
+//
+// Implements AuthenticatedUser interface
+//
+function AuthenticatedUser(backend, username, groups, acl) {
+    this.backend = backend
+    this.username = username
+    this.groups = groups
+    this.acl = acl
+
+    this.logger = Logger.logger.child({sub: username})
+    return this
+}
+
+
+AuthenticatedUser.prototype.has_authorization_for_package = function(action, package, callback) {
+    var self = this
+    self.acl.has_authorization_for_package(self.username, self.groups, action, package, function(err, is_authorized){
+        if (is_authorized) {
+            self.logger.info({
+                user: self.username,
+                action: action,
+                package: package,
+                matching: is_authorized,
+            }, 'Authorized user @{user} for action @{action} to package @{package} matching @{matching}')
+        } else {
+            self.logger.warn({
+                user: self.username,
+                action: action,
+                package: package,
+            }, 'Failed to authorize user @{user} for action @{action} to package @{package}')
+        }
+        callback(err, !!is_authorized)
+    })
+}
+
+AuthenticatedUser.prototype.has_authorization_for_uplink = function(action, package, uplink, callback) {
+    var self = this
+    self.acl.has_authorization_for_uplink(self.username, self.groups, action, package, uplink, function(err, is_authorized){
+        if (is_authorized) {
+            self.logger.info({
+                user: self.username,
+                action: action,
+                package: package,
+                uplink: uplink,
+                matching: is_authorized,
+            }, 'Authorized user @{user} for action @{action} to package @{package} on uplink @{uplink} matching @{matching}')
+        } else {
+            self.logger.warn({
+                user: self.username,
+                action: action,
+                package: package,
+                uplink: uplink,
+            }, 'Failed to authorize user @{user} for action @{action} to package @{package} on uplink @{uplink}')
+        }
+        callback(err, !!is_authorized)
+    })
+}
+
+AuthenticatedUser.prototype.toString = function() {
+    return this.username
+}
+
+module.exports = AuthenticatedUser

--- a/lib/config.js
+++ b/lib/config.js
@@ -5,19 +5,6 @@ var assert = require('assert')
   , UError = require('./error').UserError
   , utils = require('./utils')
 
-// [[a, [b, c]], d] -> [a, b, c, d]
-function flatten(array) {
-	var result = []
-	for (var i=0; i<array.length; i++) {
-		if (Array.isArray(array[i])) {
-			result.push.apply(result, flatten(array[i]))
-		} else {
-			result.push(array[i])
-		}
-	}
-	return result
-}
-
 function Config(config) {
 	if (!(this instanceof Config)) return new Config(config)
 	for (var i in config) {
@@ -29,75 +16,16 @@ function Config(config) {
 
 	assert(this.storage, 'CONFIG: storage path not defined')
 
-	var users = {all:true, anonymous:true, 'undefined':true, owner:true, none:true}
+	if (this['packages'] == null) this['packages'] = {}
+	assert(utils.is_object(this['packages']), 'CONFIG: bad "packages" value (object expected)')
 
-	var check_user_or_uplink = function(arg) {
-		assert(arg !== 'all' && arg !== 'owner' && arg !== 'anonymous' && arg !== 'undefined' && arg !== 'none', 'CONFIG: reserved user/uplink name: ' + arg)
-		assert(!arg.match(/\s/), 'CONFIG: invalid user name: ' + arg)
-		assert(users[arg] == null, 'CONFIG: duplicate user/uplink name: ' + arg)
-		users[arg] = true
-	}
-
-	;['users', 'uplinks', 'packages'].forEach(function(x) {
-		if (this[x] == null) this[x] = {}
-		assert(utils.is_object(this[x]), 'CONFIG: bad "'+x+'" value (object expected)')
-	})
-
-	for (var i in this.users) check_user_or_uplink(i)
-	for (var i in this.uplinks) check_user_or_uplink(i)
-
-	for (var i in this.users) {
-		assert(this.users[i].password, 'CONFIG: no password for user: ' + i)
-		assert(
-			typeof(this.users[i].password) === 'string' &&
-			this.users[i].password.match(/^[a-f0-9]{40}$/)
-		, 'CONFIG: wrong password format for user: ' + i + ', sha1 expected')
-	}
-
-	for (var i in this.uplinks) {
-		assert(this.uplinks[i].url, 'CONFIG: no url for uplink: ' + i)
-		assert(
-			typeof(this.uplinks[i].url) === 'string'
-		, 'CONFIG: wrong url format for uplink: ' + i)
-		this.uplinks[i].url = this.uplinks[i].url.replace(/\/$/, '')
-	}
-
-	function check_userlist(i, hash, action) {
-		if (hash[action] == null) hash[action] = []
-
-		// if it's a string, split it to array
-		if (typeof(hash[action]) === 'string') {
-			hash[action] = hash[action].split(/\s+/)
-		}
-
-		assert(
-			typeof(hash[action]) === 'object' &&
-			Array.isArray(hash[action])
-		, 'CONFIG: bad "'+i+'" package '+action+' description (array or string expected)')
-		hash[action] = flatten(hash[action])
-		hash[action].forEach(function(user) {
-			assert(
-				users[user] != null
-			, 'CONFIG: "'+i+'" package: user "'+user+'" doesn\'t exist')
-		})
-	}
-
-	for (var i in this.packages) {
-		assert(
-			typeof(this.packages[i]) === 'object' &&
-			!Array.isArray(this.packages[i])
-		, 'CONFIG: bad "'+i+'" package description (object expected)')
-
-		check_userlist(i, this.packages[i], 'allow_access')
-		check_userlist(i, this.packages[i], 'allow_publish')
-		check_userlist(i, this.packages[i], 'proxy_access')
-		check_userlist(i, this.packages[i], 'proxy_publish')
-
-		// deprecated
-		check_userlist(i, this.packages[i], 'access')
-		check_userlist(i, this.packages[i], 'proxy')
-		check_userlist(i, this.packages[i], 'publish')
-	}
+    for (var i in this.uplinks) {
+        assert(this.uplinks[i].url, 'CONFIG: no url for uplink: ' + i)
+        assert(
+            typeof(this.uplinks[i].url) === 'string'
+        , 'CONFIG: wrong url format for uplink: ' + i)
+        this.uplinks[i].url = this.uplinks[i].url.replace(/\/$/, '')
+    }
 
 	// loading these from ENV if aren't in config
 	;['http_proxy', 'https_proxy', 'no_proxy'].forEach((function(v) {
@@ -125,29 +53,6 @@ function Config(config) {
 	return this
 }
 
-function allow_action(package, who, action) {
-	return (this.get_package_setting(package, action) || []).reduce(function(prev, curr) {
-		if (curr === String(who) || curr === 'all') return true
-		return prev
-	}, false)
-}
-
-Config.prototype.allow_access = function(package, user) {
-	return allow_action.call(this, package, user, 'allow_access') || allow_action.call(this, package, user, 'access')
-}
-
-Config.prototype.allow_publish = function(package, user) {
-	return allow_action.call(this, package, user, 'allow_publish') || allow_action.call(this, package, user, 'publish')
-}
-
-Config.prototype.proxy_access = function(package, uplink) {
-	return allow_action.call(this, package, uplink, 'proxy_access') || allow_action.call(this, package, uplink, 'proxy')
-}
-
-Config.prototype.proxy_publish = function(package, uplink) {
-	return allow_action.call(this, package, uplink, 'proxy_publish')
-}
-
 Config.prototype.get_package_setting = function(package, setting) {
 	for (var i in this.packages) {
 		if (minimatch.makeRe(i).exec(package)) {
@@ -155,38 +60,6 @@ Config.prototype.get_package_setting = function(package, setting) {
 		}
 	}
 	return undefined
-}
-
-Config.prototype.authenticate = function(user, password, cb) {
-	if (this.users != null && this.users[user] != null) {
-		// if user exists in this.users, verify password against it no matter what is in htpasswd
-		return cb(null, crypto.createHash('sha1').update(password).digest('hex') === this.users[user].password)
-	}
-
-	if (!this.HTPasswd) return cb(null, false)
-	this.HTPasswd.reload(function() {
-		cb(null, this.HTPasswd.verify(user, password))
-	}.bind(this))
-}
-
-Config.prototype.add_user = function(user, password, cb) {
-	if (this.users && this.users[user]) return cb(new UError({
-		status: 403,
-		message: 'this user already exists',
-	}))
-
-	if (this.HTPasswd) {
-		if (this.max_users || this.max_users == null) {
-			var max_users = Number(this.max_users || Infinity)
-			this.HTPasswd.add_user(user, password, max_users, cb)
-			return
-		}
-	}
-
-	return cb(new UError({
-		status: 409,
-		message: 'registration is disabled',
-	}))
 }
 
 module.exports = Config

--- a/lib/config_def.yaml
+++ b/lib/config_def.yaml
@@ -9,6 +9,26 @@ users:
     # crypto.createHash('sha1').update(pass).digest('hex')
     password: __PASSWORD__
 
+# a list of auth backends
+auth:
+  local:
+    type: local
+  # ldap:
+  #   type: ldap
+  #   groupNameAttribute: 'cn'
+  #   client_options:
+  #     url: "ldaps://ldap.example.com"
+  #     adminDn: "cn=admin,dc=example,dc=com"
+  #     adminPassword: "admin"
+  #     searchBase: "ou=People,dc=example,dc=com"
+  #     searchFilter: "(uid={{username}})"
+  #     cache: False
+  #     searchAttributes:
+  #       - "*"
+  #       - memberOf
+  #     tlsOptions:
+  #       rejectUnauthorized: False
+
 title: Sinopia
 # logo: logo.png
 
@@ -55,8 +75,10 @@ packages:
     # this includes non-authenticated users
     allow_access: all
 
-    # allow 'admin' to publish packages
-    allow_publish: admin
+    # allow local 'admin' user, and group 'Administrators' to publish packages
+    allow_publish:
+      - admin
+      - %Administrators
 
     # if package is not available locally, proxy requests to 'npmjs' registry
     proxy: npmjs

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 var express = require('express')
   , cookies = require('cookies')
   , utils = require('./utils')
+  , Auth = require('./auth')
   , Storage = require('./storage')
   , Config = require('./config')
   , UError = require('./error').UserError
@@ -29,32 +30,35 @@ function match(regexp) {
 
 module.exports = function(config_hash) {
 	var config = new Config(config_hash)
-	  , storage = new Storage(config);
+      , auth = new Auth(config)
+      , storage = new Storage(config, auth)
 
 	search.configureStorage(storage);
 
 	var can = function(action) {
 		return function(req, res, next) {
-			if (config['allow_'+action](req.params.package, req.remoteUser)) {
-				next()
-			} else {
-				if (!req.remoteUser) {
-					if (req.remoteUserError) {
-						var message = "can't "+action+' restricted package, ' + req.remoteUserError
-					} else {
-						var message = "can't "+action+" restricted package without auth, did you forget 'npm set always-auth true'?"
-					}
+            if (!req.authenticated_user) {
+                if (req.remoteUserError) {
+                    var msg = "can't "+action+' restricted package, ' + req.remoteUserError
+                } else {
+                    var msg = "can't "+action+" restricted package without auth, did you forget 'npm set always-auth true'?"
+                }
+                return next(new UError({
+                    status: 403,
+                    msg: msg,
+                }))
+            }
+
+            req.authenticated_user.has_authorization_for_package(action, req.params.package, function(err, allowed) {
+                if (allowed) {
+    				next()
+    			} else {
 					next(new UError({
 						status: 403,
-						message: message,
-					}))
-				} else {
-					next(new UError({
-						status: 403,
-						message: 'user '+req.remoteUser+' not allowed to '+action+' it'
+						msg: 'user '+req.authenticated_user+' not allowed to '+action+' it'
 					}))
 				}
-			}
+			});
 		}
 	}
 
@@ -96,11 +100,13 @@ module.exports = function(config_hash) {
 		next()
 	})
 	app.use(Cats.middleware)
-	app.use(basic_auth(function(user, pass, cb) {
-		config.authenticate(user, pass, cb)
-	}))
-	app.use(express.json({strict: false, limit: config.max_body_size || '10mb'}))
-	app.use(express.compress())
+    // I've no idea why, but if express.json is after basic_auth when
+    // using an ldap backend, requests just hang in basic_auth - jasonrm
+    app.use(express.json({strict: false, limit: config.max_body_size || '10mb'}))
+    app.use(express.compress())
+	app.use(basic_auth(function(user, password, next) {
+       auth.authenticate(user, password, next)
+    }))
 	app.use(Middleware.anti_loop(config))
 
 	// validate all of these params as a package name
@@ -192,7 +198,7 @@ module.exports = function(config_hash) {
 		storage.search(req.param.startkey || 0, {req: req}, function(err, result) {
 			if (err) return next(err)
 			for (var pkg in result) {
-				if (!config.allow_access(pkg, req.remoteUser)) {
+				if (!config.allow_access(pkg, req.authenticated_user)) {
 					delete result[pkg]
 				}
 			}
@@ -217,15 +223,15 @@ module.exports = function(config_hash) {
 	app.get('/-/user/:org_couchdb_user', function(req, res, next) {
 		res.status(200)
 		return res.send({
-			ok: 'you are authenticated as "' + req.remoteUser + '"',
+			ok: 'you are authenticated as "' + req.authenticated_user + '"',
 		})
 	})
 
 	app.put('/-/user/:org_couchdb_user/:_rev?/:revision?', function(req, res, next) {
-		if (req.remoteUser != null) {
+		if (req.authenticated_user != null) {
 			res.status(201)
 			return res.send({
-				ok: 'you are authenticated as "' + req.remoteUser + '"',
+				ok: 'you are authenticated as "' + req.authenticated_user + '"',
 			})
 		} else {
 			if (typeof(req.body.name) !== 'string' || typeof(req.body.password) !== 'string') {
@@ -234,7 +240,7 @@ module.exports = function(config_hash) {
 					message: 'user/password is not found in request (npm issue?)',
 				}))
 			}
-			config.add_user(req.body.name, req.body.password, function(err) {
+			auth.add_user(req.body.name, req.body.password, function(err) {
 				if (err) {
 					if (err.status < 500 && err.message === 'this user already exists') {
 						// with npm registering is the same as logging in
@@ -355,7 +361,7 @@ module.exports = function(config_hash) {
 				after_change(err, 'package changed')
 			})
 		} else {
-			storage.add_package(name, metadata, function(err) {
+			storage.add_package(name, metadata, {req: req}, function(err) {
 				after_change(err, 'created new package')
 			})
 		}

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -56,7 +56,7 @@ module.exports.basic_auth = function basic_auth(callback) {
 
 		var authorization = req.headers.authorization
 
-		if (req.remoteUser != null) return next()
+		if (req.authenticated_user != null) return next()
 		if (authorization == null) return next()
 
 		var parts = authorization.split(' ')
@@ -78,17 +78,16 @@ module.exports.basic_auth = function basic_auth(callback) {
 		var user = credentials.slice(0, index)
 		  , pass = credentials.slice(index + 1)
 
-		callback(user, pass, function(err, is_ok) {
-			if (err) return next(err)
-			if (is_ok) {
-				req.remoteUser = user
-				next()
-			} else {
-				next({
-					status: 403,
-					message: 'bad username/password, access denied',
-				})
-			}
+		callback(user, pass, function(err, authenticated_user) {
+            if (authenticated_user) {
+                req.authenticated_user = authenticated_user
+    			next()
+    		} else {
+    			next({
+    				status: 403,
+    				msg: 'bad username/password, access denied',
+    			})
+            }
 		})
 	}
 }
@@ -187,7 +186,7 @@ module.exports.log_and_etagify = function(req, res, next) {
 		req.log.warn({
 			request: {method: req.method, url: req.url},
 			level: 35, // http
-			user: req.remoteUser,
+			user: req.authenticated_user && req.authenticated_user.username,
 			status: res.statusCode,
 			error: res._sinopia_error,
 			bytes: {

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -6,6 +6,7 @@ var async = require('async')
   , mystreams = require('./streams')
   , utils = require('./utils')
   , Logger = require('./logger')
+  , lodash = require('lodash')
   , localList = require('./local-list');
 
 //
@@ -15,7 +16,7 @@ var async = require('async')
 function Storage(config) {
 	if (!(this instanceof Storage)) return new Storage(config)
 
-	this.config = config
+    this.config = config
 
 	// we support a number of uplinks, but only one local storage
 	// Proxy and Local classes should have similar API interfaces
@@ -38,7 +39,7 @@ function Storage(config) {
 //
 // Used storages: local (write) && uplinks
 //
-Storage.prototype.add_package = function(name, metadata, callback) {
+Storage.prototype.add_package = function(name, metadata, options, callback) {
 	var self = this
 
 	// NOTE:
@@ -75,7 +76,7 @@ Storage.prototype.add_package = function(name, metadata, callback) {
 	}
 
 	function check_package_remote(cb) {
-		self._sync_package_with_uplinks(name, null, {}, function(err, results, err_results) {
+		self._sync_package_with_uplinks(name, null, options, function(err, results, err_results) {
 			// something weird
 			if (err && err.status !== 404) return cb(err)
 
@@ -444,6 +445,7 @@ Storage.prototype.get_local = function(callback) {
 // returns callback(err, result, uplink_errors)
 Storage.prototype._sync_package_with_uplinks = function(name, pkginfo, options, callback) {
 	var self = this
+        , req = options.req
 
 	if (!pkginfo) {
 		var exists = false
@@ -458,73 +460,80 @@ Storage.prototype._sync_package_with_uplinks = function(name, pkginfo, options, 
 		var exists = true
 	}
 
-	var uplinks = []
-	for (var i in self.uplinks) {
-		if (self.config.proxy_access(name, i)) {
-			uplinks.push(self.uplinks[i])
-		}
+	proxy_access_authorized = function(uplink_name, callback) {
+        if (!req || !req.authenticated_user) return callback(null, false)
+		req.authenticated_user.has_authorization_for_uplink('access', name, uplink_name, function(err, is_authorized) {
+            if (is_authorized) {
+                callback(null, self.uplinks[uplink_name])
+            } else {
+                callback(null, false)
+            }
+		})
 	}
 
-	async.map(uplinks, function(up, cb) {
-		var _options = Object.create(options)
-		if (utils.is_object(pkginfo._uplinks[up.upname])) {
-			var fetched = pkginfo._uplinks[up.upname].fetched
-			if (fetched && fetched > (Date.now() - up.maxage)) {
-				return cb()
+	async.map(Object.keys(self.uplinks), proxy_access_authorized, function(err, uplinks) {
+        uplinks = lodash.filter(uplinks)
+		async.map(uplinks, function(up, cb) {
+			var _options = Object.create(options)
+			if (utils.is_object(pkginfo._uplinks[up.upname])) {
+				var fetched = pkginfo._uplinks[up.upname].fetched
+				if (fetched && fetched > (Date.now() - up.maxage)) {
+					return cb()
+				}
+
+				_options.etag = pkginfo._uplinks[up.upname].etag
 			}
 
-			_options.etag = pkginfo._uplinks[up.upname].etag
-		}
+			up.get_package(name, _options, function(err, up_res, etag) {
+				if (err && err.status === 304)
+					pkginfo._uplinks[up.upname].fetched = Date.now()
 
-		up.get_package(name, _options, function(err, up_res, etag) {
-			if (err && err.status === 304)
-				pkginfo._uplinks[up.upname].fetched = Date.now()
+				if (err || !up_res) return cb(null, [err || new Error('no data')])
 
-			if (err || !up_res) return cb(null, [err || new Error('no data')])
+				try {
+					utils.validate_metadata(up_res, name)
+				} catch(err) {
+					self.logger.error({
+						sub: 'out',
+						err: err,
+					}, 'package.json validating error @{!err.message}\n@{err.stack}')
+					return cb(null, [err])
+				}
 
-			try {
-				utils.validate_metadata(up_res, name)
-			} catch(err) {
-				self.logger.error({
-					sub: 'out',
-					err: err,
-				}, 'package.json validating error @{!err.message}\n@{err.stack}')
-				return cb(null, [err])
+				pkginfo._uplinks[up.upname] = {
+					etag: etag,
+					fetched: Date.now()
+				}
+
+				try {
+					Storage._merge_versions(pkginfo, up_res, self.config)
+				} catch(err) {
+					self.logger.error({
+						sub: 'out',
+						err: err,
+					}, 'package.json parsing error @{!err.message}\n@{err.stack}')
+					return cb(null, [err])
+				}
+
+				// if we got to this point, assume that the correct package exists
+				// on the uplink
+				exists = true
+				cb()
+			})
+		}, function(err, uplink_errors) {
+			assert(!err && Array.isArray(uplink_errors))
+
+			if (!exists) {
+				return callback(new UError({
+					status: 404,
+					message: 'no such package available'
+				}), null, uplink_errors)
 			}
 
-			pkginfo._uplinks[up.upname] = {
-				etag: etag,
-				fetched: Date.now()
-			}
-
-			try {
-				Storage._merge_versions(pkginfo, up_res, self.config)
-			} catch(err) {
-				self.logger.error({
-					sub: 'out',
-					err: err,
-				}, 'package.json parsing error @{!err.message}\n@{err.stack}')
-				return cb(null, [err])
-			}
-
-			// if we got to this point, assume that the correct package exists
-			// on the uplink
-			exists = true
-			cb()
-		})
-	}, function(err, uplink_errors) {
-		assert(!err && Array.isArray(uplink_errors))
-
-		if (!exists) {
-			return callback(new UError({
-				status: 404,
-				message: 'no such package available'
-			}), null, uplink_errors)
-		}
-
-		self.local.update_versions(name, pkginfo, function(err, pkginfo) {
-			if (err) return callback(err)
-			return callback(null, pkginfo, uplink_errors)
+			self.local.update_versions(name, pkginfo, function(err, pkginfo) {
+				if (err) return callback(err)
+				return callback(null, pkginfo, uplink_errors)
+			})
 		})
 	})
 }

--- a/package.yaml
+++ b/package.yaml
@@ -32,6 +32,9 @@ dependencies:
   minimatch: '>= 0.2.14'
   bunyan: '>= 0.22.1'
   mkdirp: '>= 0.3.5'
+  ldapauth-fork: ">= 2.2.12"
+  ldapjs: ">= 0.7.1"
+  lodash: ">= 2.4.1"
   handlebars: '1.x.x'
   helpers.less: 'git://github.com/bpeacock/helpers.less.git'
   highlight.js: '^8.0.0'


### PR DESCRIPTION
So I wrote this a couple of months back, but didn't do a pull request because it felt like a bit of an ugly hack.

Well, it's still an ugly hack, but since I saw another request for LDAP support in #84, I figured I might as well make it a little more public. I wish I could spend more time cleaning this up, but unfortunately I really am lacking the time, so no hard feelings if you don't want to merge/support this. It works well enough for our needs right now so it's hard to justify spending any more work time on this.

Part of the changes were to the authentication and storage auth flow. I moved authentication/authorization related things out of lib/config and into lib/auth, lib/auth-local, and lib/auth-ldap. Most of the authorization functions are now in lib/access-control-list, which is used by lib/authenticated-user.

The recent addition of htpasswd support does conflict a little as it will create a user even if it fails to login to the LDAP server if both ldap and local backends are enabled and users_file is set. I moved the htpasswd related functions into auth-local, although now that I think about it, auth-htpasswd might have been better.
