### PR TITLE
Allow authentication header to be passed-thru to upstream when resolving packages.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -143,6 +143,10 @@ Config.prototype.proxy_publish = function(package, uplink) {
 	//return allow_action.call(this, package, uplink, 'proxy_publish')
 }
 
+Config.prototype.auth_passthrough = function(package) {
+	return this.get_package_setting(package, "auth_passthrough") || false;
+};
+
 Config.prototype.get_package_setting = function(package, setting) {
 	for (var i in this.packages) {
 		if (minimatch.makeRe(i).exec(package)) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -116,7 +116,8 @@ module.exports = function(config_hash) {
 
 	// TODO: anonymous user?
 	app.get('/:package/:version?', can('access'), function(req, res, next) {
-		storage.get_package(req.params.package, {req: req}, function(err, info) {
+		var opts = {req: req, auth_passthrough: config.auth_passthrough(req.params.package)};
+		storage.get_package(req.params.package, opts, function(err, info) {
 			if (err) return next(err)
 			info = utils.filter_tarball_urls(info, req, config)
 
@@ -144,7 +145,9 @@ module.exports = function(config_hash) {
 	})
 
 	app.get('/:package/-/:filename', can('access'), function(req, res, next) {
-		var stream = storage.get_tarball(req.params.package, req.params.filename)
+		var opts = {req: req, auth_passthrough: config.auth_passthrough(req.params.package)};
+
+		var stream = storage.get_tarball(req.params.package, opts, req.params.filename)
 		stream.on('content-length', function(v) {
 			res.header('Content-Length', v)
 		})

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -178,7 +178,7 @@ Storage.prototype.get_readme = function(name, version, callback) {
 //
 // Used storages: local || uplink (just one)
 //
-Storage.prototype.get_tarball = function(name, filename) {
+Storage.prototype.get_tarball = function(name, options, filename) {
 	var stream = new mystreams.ReadTarballStream()
 	stream.abort = function() {}
 
@@ -209,7 +209,7 @@ Storage.prototype.get_tarball = function(name, filename) {
 			} else {
 				// we know nothing about this file, trying to get information elsewhere
 
-				self._sync_package_with_uplinks(name, info, {}, function(err, info) {
+				self._sync_package_with_uplinks(name, info, options, function(err, info) {
 					if (err) return stream.emit('error', err)
 
 					if (!info._distfiles || info._distfiles[filename] == null) {
@@ -246,7 +246,11 @@ Storage.prototype.get_tarball = function(name, filename) {
 
 		var savestream = self.local.add_tarball(name, filename)
 		function on_open() {
-			var rstream2 = uplink.get_url(file.url)
+			var headers = {};
+			if (options.auth_passthrough) {
+				headers['Authorization'] = options.req.headers.authorization;
+			}
+			var rstream2 = uplink.get_url(file.url, headers)
 			rstream2.on('error', function(err) {
 				if (savestream) savestream.abort()
 				savestream = null

--- a/lib/up-storage.js
+++ b/lib/up-storage.js
@@ -256,6 +256,11 @@ Storage.prototype.get_package = function(name, options, callback) {
 		headers['If-None-Match'] = options.etag
 		headers['Accept'] = 'application/octet-stream'
 	}
+
+	if (options.auth_passthrough) {
+		headers['Authorization'] = options.req.headers.authorization;
+	}
+
 	this._add_proxy_headers(options.req, headers)
 
 	this.request({
@@ -278,10 +283,20 @@ Storage.prototype.get_package = function(name, options, callback) {
 
 Storage.prototype.get_tarball = function(name, options, filename) {
 	if (!options) options = {}
-	return this.get_url(this.config.url + '/' + name + '/-/' + filename)
+
+	var headers = {};
+	if (options.auth_passthrough) {
+		headers['Authorization'] = options.req.headers.authorization;
+	}
+
+	return this.get_url(this.config.url + '/' + name + '/-/' + filename, headers)
 }
 
-Storage.prototype.get_url = function(url) {
+Storage.prototype.get_url = function(url, headers) {
+	headers = headers || {};
+	if (!headers.Accept) {
+		headers.Accept = 'application/octet-stream';
+	}
 	var stream = new mystreams.ReadTarballStream()
 	stream.abort = function() {}
 	var current_length = 0, expected_length
@@ -289,9 +304,7 @@ Storage.prototype.get_url = function(url) {
 	var rstream = this.request({
 		uri_full: url,
 		encoding: null,
-		headers: {
-			Accept: 'application/octet-stream',
-		},
+		headers: headers,
 	})
 
 	rstream.on('response', function(res) {


### PR DESCRIPTION
I love sinopia. It's shaping up to be like the swiss-army knife for bespoke npm registry setups.

Let me explain what this is for a little. We want to roll our own private NPM registry for our internal packages. However, we already have multiple sinopia proxies in place for different geographical locations. These proxies currently require no authentication, as they were just there to speed up resolving requests to the public NPM registry. Now that we want private NPM endpoints, we want developers to be able to continue using the "edge proxies" - but certain packages will split out to hit a different registry. When that happens, we want to be able to put sinopia into a sort of "dumb mode", in which its own ACL is ignored, but it forwards the request _including_ any given authentication data to the upstream.

One of the primary reasons we want to do this is to avoid needing to roll authentication on every edge locations. Here's a naive example of how this PR would be useful:

Imagine this in your config.yaml:

```
packages:
  'private-*':
    allow_access: all
    auth_passthrough: true
    proxy: private-registry
  '*':
    proxy: npmjs
```

In the example above, this PR will ensure that sinopia doesn't do any ACL checks, but passes the inbound authentication header along to the `private-registry`.

An aside, part of this use-case is we're going to want to be able to completely disable resolved packages from upstream being persisted in local storage for certain package patterns. Is that currently possible? If not, I'll be submitting another PR for that :)
