### PR TITLE
Fixes issue #128 (Sinopia crash after click in web UI)

### DIFF
--- a/lib/index-web.js
+++ b/lib/index-web.js
@@ -73,7 +73,7 @@ module.exports = function(app, config, storage) {
 
 	app.get('/-/readme/:package/:version', function(req, res, next) {
 		storage.get_readme(req.params.package, req.params.version, function(readme) {
-			res.send(marked(readme))
+			readme instanceof Error ? res.send(404) : res.send(marked(readme))
 		})
 	})
 }

--- a/lib/static/main.js
+++ b/lib/static/main.js
@@ -97,6 +97,15 @@ $(function() {
 					transitionComplete(function() {
 						$entry.css('height', 'auto');
 					});
+				},
+				error: function(jqxhr, status, error) {
+					var $readme = $("<div class='readme'>No README file</div>").appendTo($entry);
+
+					$entry.height(height + $readme.outerHeight());
+
+					transitionComplete(function() {
+						$entry.css('height', 'auto');
+					});
 				}
 			});
 		}


### PR DESCRIPTION
This fix prints out a stub "No README" in place of a real README contents in case when $.ajax returnes an error. Server code returns 404 if readme is an instance of Error.
