### PR TITLE
Fix wrongly documented max_users in auto generated config.yaml

### DIFF
--- a/lib/config_def.yaml
+++ b/lib/config_def.yaml
@@ -24,7 +24,7 @@ auth:
   htpasswd:
     file: ./htpasswd
     # Maximum amount of users allowed to register, defaults to "+inf".
-    # You can set this to 0 to disable registration.
+    # You can set this to -1 to disable registration.
     #max_users: 1000
 
 # a list of other known repositories we can talk to


### PR DESCRIPTION
See rlidwka/sinopia-htpasswd#3 and rlidwka/sinopia-htpasswd#6
