### PR TITLE
No latest tag until a latest tag is published

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -298,7 +298,7 @@ Storage.prototype.get_package = function(name, options, callback) {
 				if (whitelist.indexOf(i) === -1) delete result[i]
 			}
 
-			if (self.config.ignore_latest_tag || !result['dist-tags'].latest) {
+			if (self.config.ignore_latest_tag) {
 				result['dist-tags'].latest = utils.semver_sort(Object.keys(result.versions))
 			}
 


### PR DESCRIPTION
With the current setup, when you are first pushing releases with a --tag=rc for example, sinopia insists that there is a latest tag.
I believe checking for the igore_latest_tag is enough to get the old sinopia behavior back. No need to add the latest dist-tag if non latest version was added.
