### PR TITLE
web-gui/updating entries shown on index page

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -411,8 +411,8 @@ Storage.prototype.get_local = function(callback) {
 	var getPackage = function(i) {
 		self.local.get_package(locals[i], function(err, info) {
 			if (!err) {
-				var latest = Array.isArray(info['dist-tags'].latest) 
-				           ? utils.semver_sort(info['dist-tags'].latest)[0]
+				var latest = Array.isArray(info['dist-tags'].latest)
+				           ? utils.semver_sort(info['dist-tags'].latest).pop()
 				           : info['dist-tags'].latest
 				if (info.versions[latest]) {
 					packages.push(info.versions[latest])
@@ -548,4 +548,3 @@ Storage._merge_versions = function(local, up, config) {
 }
 
 module.exports = Storage
-


### PR DESCRIPTION
`utils.semver_sort` will put the put the package's dist-tags in order from least to greatest (if that makes sense for semver). Taking the first index of the array will always return the lowest semver, and we want to display the latest/highest version on initial load (using `.pop()`)
