### PR TITLE
Checks whether process.env.HOME exists

### DIFF
--- a/lib/config-path.js
+++ b/lib/config-path.js
@@ -34,17 +34,16 @@ function create_config_file(config_path) {
 }
 
 function get_paths() {
-  var try_paths = []
-  if(typeof process.env.HOME == "string"){
-    var xdg_config = process.env.XDG_CONFIG_HOME
-                  || Path.join(process.env.HOME, '.config')
-    if (folder_exists(xdg_config)) {
-      try_paths.push({
-        path: Path.join(xdg_config, 'sinopia', 'config.yaml'),
-        type: 'xdg',
-      })
-    }
+  var try_paths = [];
+  var xdg_config = process.env.XDG_CONFIG_HOME
+                || process.env.HOME && Path.join(process.env.HOME, '.config')
+  if (folder_exists(xdg_config)) {
+    try_paths.push({
+      path: Path.join(xdg_config, 'sinopia', 'config.yaml'),
+      type: 'xdg',
+    })
   }
+  
   if (process.platform === 'win32'
    && process.env.APPDATA
    && folder_exists(process.env.APPDATA)) {


### PR DESCRIPTION
Checks whether process.env.HOME exists before calling Path.join
Was not able to start sinopia on my fresh windows install due to this error.
