### PR TITLE
add npm_client_version config option

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -45,6 +45,10 @@ function Config(config) {
     }
   }
 
+  if (!self.npm_client_version) {
+    self.npm_client_version = "*"
+  }
+
   var users = {all:true, anonymous:true, 'undefined':true, owner:true, none:true}
 
   var check_user_or_uplink = function(arg) {

--- a/lib/index-api.js
+++ b/lib/index-api.js
@@ -4,6 +4,7 @@ var expressJson5  = require('express-json5')
 var Error         = require('http-errors')
 var Path          = require('path')
 var Middleware    = require('./middleware')
+var Semver        = require('semver');
 var Utils         = require('./utils')
 var expect_json   = Middleware.expect_json
 var match         = Middleware.match
@@ -119,6 +120,11 @@ module.exports = function(config, auth, storage) {
     var token = (req.body.name && req.body.password)
               ? auth.aes_encrypt(req.body.name + ':' + req.body.password).toString('base64')
               : undefined
+
+    if (!Semver.satisfies(req.header('version'), config.npm_client_version) && config.npm_client_version !== '*') {
+      return next( Error[422]('Your npm version is not accepted. Required: "' + config.npm_client_version + '" Received: "' + req.header('version') + '"') )
+    }
+
     if (req.remote_user.name != null) {
       res.status(201)
       return next({


### PR DESCRIPTION
- to restrict which npm clients can login

I'd like the ability to disallow npm login / npm adduser for certain versions of the npm client. 
This information can be read from the version request header.

Use case: I only want to allow login for users who have npm >= 1.5, since npm < 1.5 stores the user's base64-encoded password in plaintext under their local ~/.npmrc file. This is particularly important if you are using the sinopia-ldap plugin, since this password is the user's LDAP password.

see: https://github.com/rlidwka/sinopia/issues/187
