### PR TITLE
Fixed issue with not being able to disable the web interface

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -90,7 +90,9 @@ module.exports = function(config_hash) {
   app.use(require('./index-api')(config, auth, storage))
 
   if (config.web && config.web.enable === false) {
-    next( Error[404]('web interface is disabled in the config file') )
+    app.get('/*', function(req, res, next) {
+      next( Error[404]('web interface is disabled in the config file') )
+    })
   } else {
     app.use(require('./index-web')(config, auth, storage))
   }


### PR DESCRIPTION
Current master gives the following exception:

```javascript
sinopia/lib/index.js:93
    next( Error[404]('web interface is disabled in the config file') )
    ^
ReferenceError: next is not defined
```