### PR TITLE
Fixes NPE on POST _session when npm tries to authenticate

### DIFF
--- a/lib/index-api.js
+++ b/lib/index-api.js
@@ -100,7 +100,7 @@ module.exports = function(config, auth, storage) {
 
   // placeholder 'cause npm require to be authenticated to publish
   // we do not do any real authentication yet
-  app.post('/_session', Cookies.express(), function(req, res) {
+  app.post('/_session', Cookies.express(), function(req, res, next) {
     res.cookies.set('AuthSession', String(Math.random()), {
       // npmjs.org sets 10h expire
       expires: new Date(Date.now() + 10*60*60*1000)


### PR DESCRIPTION
The npm publish command currently fails on an "500 Internal Error" while trying to log in the Sinopia repository.
This restores the expected behaviour