### PR TITLE
#215 using includes instead of contains, ensuring es6-shim >= 0.21 is used

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -131,7 +131,7 @@ function print(type, msg, obj, colors) {
     }
 
     if (typeof(str) === 'string') {
-      if (!colors || str.contains('\n')) {
+      if (!colors || str.includes('\n')) {
         return str
       } else if (is_error) {
         return '\033[31m' + str + '\033[39m'

--- a/package.yaml
+++ b/package.yaml
@@ -25,7 +25,7 @@ dependencies:
   cookies: '>=0.5.0 <1.0.0-0'
   request: '>=2.31.0 <3.0.0-0'
   async: '>=0.9.0 <1.0.0-0'
-  es6-shim: '>=0.20 <1.0.0-0'
+  es6-shim: '>=0.21 <1.0.0-0'
 
   # 2.x and 3.x have the same interface
   semver: '>=2.2.1 <4.0.0-0'


### PR DESCRIPTION
Just using `string.includes` instead of `string.contains`. 