### PR TITLE
Running multiple Sinopia nodes behind a load balancer, keep local data in sync

### DIFF
--- a/lib/local-data.js
+++ b/lib/local-data.js
@@ -34,6 +34,23 @@ LocalData.prototype.get = function() {
   return this.data.list
 }
 
+LocalData.prototype.get = function() {
+   
+  // When doing a GET request, sync the local storage to ensure it is up todat
+  // This functionality is need when running multiple Sinopia node behind a load balancer
+  // and local storage is configured to use NFS.
+  // No significant performance issues have been detected to parse the local storage on each GET request.
+
+  try {
+    this.data = JSON.parse(fs.readFileSync(this.path, 'utf8'))
+  } catch(_) {
+      this.data = { list: [] }
+  }
+
+  return this.data.list
+}
+
+
 LocalData.prototype.sync = function() {
   // Uses sync to prevent ugly race condition
   try {

--- a/lib/local-data.js
+++ b/lib/local-data.js
@@ -36,7 +36,7 @@ LocalData.prototype.get = function() {
 
 LocalData.prototype.get = function() {
    
-  // When doing a GET request, sync the local storage to ensure it is up todat
+  // When doing a GET request, sync the local storage to ensure it is up to date
   // This functionality is need when running multiple Sinopia node behind a load balancer
   // and local storage is configured to use NFS.
   // No significant performance issues have been detected to parse the local storage on each GET request.


### PR DESCRIPTION
I have made a change to the get request method. It will sync the local data folder on each GET request. This functionality is needed to ensure that all Sinopia nodes are presenting the correct state for the data storage folder.

I have multiple Sinopia node all sharing a NFS share as it's local data storage folder.

Would be great to get this included in master branch.
