### PR TITLE
adds nocache middleware

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 var express       = require('express')
 var Error         = require('http-errors')
 var compression   = require('compression')
+var nocache       = require('nocache')
 var Auth          = require('./auth')
 var Logger        = require('./logger')
 var Config        = require('./config')
@@ -45,6 +46,7 @@ module.exports = function(config_hash) {
   }
 
   app.use(Middleware.log)
+  app.use(nocache())
   app.use(error_reporting_middleware)
   app.use(function(req, res, next) {
     res.setHeader('X-Powered-By', config.user_agent)

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -679,6 +679,10 @@
     },
     "sinopia-htpasswd": {
       "version": "0.4.5"
+    },
+    "nocache": {
+      "version": "0.2.0",
+      "from": "nocache@"
     }
   }
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -681,8 +681,8 @@
       "version": "0.4.5"
     },
     "nocache": {
-      "version": "0.2.0",
-      "from": "nocache@"
+      "version": "0.3.0",
+      "from": "nocache@latest"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,89 @@
+{
+  "name": "sinopia",
+  "version": "1.2.2",
+  "description": "Private npm repository server",
+  "author": {
+    "name": "Alex Kocharin",
+    "email": "alex@kocharin.ru"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/rlidwka/sinopia"
+  },
+  "main": "index.js",
+  "bin": {
+    "sinopia": "./bin/sinopia"
+  },
+  "dependencies": {
+    "express": ">=5.0.0-0 <6.0.0-0",
+    "express-json5": ">=0.1.0 <1.0.0-0",
+    "body-parser": ">=1.9.2 <2.0.0-0",
+    "compression": ">=1.2.0 <2.0.0-0",
+    "commander": ">=2.3.0 <3.0.0-0",
+    "js-yaml": ">=3.0.1 <4.0.0-0",
+    "cookies": ">=0.5.0 <1.0.0-0",
+    "request": ">=2.31.0 <3.0.0-0",
+    "async": ">=0.9.0 <1.0.0-0",
+    "es6-shim": "0.21.x",
+    "semver": ">=2.2.1 <5.0.0-0",
+    "minimatch": ">=0.2.14 <2.0.0-0",
+    "bunyan": ">=0.22.1 <2.0.0-0",
+    "handlebars": "2.x",
+    "highlight.js": "8.x",
+    "lunr": ">=0.5.2 <1.0.0-0",
+    "render-readme": ">=0.2.1",
+    "jju": "1.x",
+    "mkdirp": ">=0.3.5 <1.0.0-0",
+    "sinopia-htpasswd": ">= 0.4.3",
+    "http-errors": ">=1.2.0",
+    "nocache": ">=0.2.0 <1.0.0.0-0"
+  },
+  "optionalDependencies": {
+    "fs-ext": ">=0.4.1 <1.0.0-0",
+    "crypt3": ">=0.1.6 <1.0.0-0"
+  },
+  "devDependencies": {
+    "rimraf": ">=2.2.5 <3.0.0-0",
+    "bluebird": "2 >=2.9",
+    "mocha": "2 >=2.2.3",
+    "eslint": ">= 0.18",
+    "browserify": "7.x",
+    "browserify-handlebars": "1.x",
+    "grunt": ">=0.4.4 <1.0.0-0",
+    "grunt-cli": "*",
+    "grunt-browserify": ">=2.0.8 <3.0.0-0",
+    "grunt-contrib-less": ">=0.11.0 <1.0.0-0",
+    "grunt-contrib-watch": ">=0.6.1 <1.0.0-0",
+    "unopinionate": ">=0.0.4 <1.0.0-0",
+    "onclick": ">=0.1.0 <1.0.0-0",
+    "transition-complete": ">=0.0.2 <1.0.0-0"
+  },
+  "keywords": [
+    "private",
+    "package",
+    "repository",
+    "registry",
+    "modules",
+    "proxy",
+    "server"
+  ],
+  "scripts": {
+    "test": "eslint --reset . && mocha ./test/functional ./test/unit",
+    "test-travis": "eslint --reset . && mocha -R spec ./test/functional ./test/unit",
+    "test-only": "mocha ./test/functional ./test/unit",
+    "lint": "eslint --reset .",
+    "prepublish": "js-yaml package.yaml > package.json",
+    "clean-shrinkwrap": "node -e '\n  function clean(j) {\n    if (!j) return\n    for (var k in j) {\n      delete j[k].from\n      delete j[k].resolved\n      if (j[k].dependencies) clean(j[k].dependencies)\n    }\n  }\n  x = JSON.parse(require(\"fs\").readFileSync(\"./npm-shrinkwrap.json\"))\n  clean(x.dependencies)\n  x = JSON.stringify(x, null, \"  \")\n  require(\"fs\").writeFileSync(\"./npm-shrinkwrap.json\", x + \"\\n\")\n'\n"
+  },
+  "engines": {
+    "node": ">=0.10"
+  },
+  "preferGlobal": true,
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
+  "license": {
+    "type": "WTFPL",
+    "url": "http://www.wtfpl.net/txt/copying/"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "mkdirp": ">=0.3.5 <1.0.0-0",
     "sinopia-htpasswd": ">= 0.4.3",
     "http-errors": ">=1.2.0",
-    "nocache": ">=0.2.0 <1.0.0.0-0"
+    "nocache": ">=0.3.0 <1.0.0.0-0"
   },
   "optionalDependencies": {
     "fs-ext": ">=0.4.1 <1.0.0-0",

--- a/package.yaml
+++ b/package.yaml
@@ -24,6 +24,7 @@ dependencies:
   express-json5: '>=0.1.0 <1.0.0-0'
   body-parser: '>=1.9.2 <2.0.0-0'
   compression: '>=1.2.0 <2.0.0-0'
+  nocache: '>=0.3.0 <1.0.0-0'
 
   commander: '>=2.3.0 <3.0.0-0'
   js-yaml: '>=3.0.1 <4.0.0-0'


### PR DESCRIPTION
I had issues putting sinopia into production because it does not explicitly set caching headers.  There are probably smarter, more targeted decisions to be made, but I think a good practice is to set broad no-cache headers early, and adjust them later in the request chain if possible.

This PR accomplishes the first part, setting no-cache headers by default using the [helmetjs/nocache](https://github.com/helmetjs/nocache) middleware.
