### PR TITLE
allow custom middleware plugins

### DIFF
--- a/lib/index-api.js
+++ b/lib/index-api.js
@@ -3,6 +3,7 @@ var Cookies       = require('cookies')
 var express       = require('express')
 var expressJson5  = require('express-json5')
 var Error         = require('http-errors')
+var load_plugins  = require('./plugin-loader').load_plugins
 var Path          = require('path')
 var Middleware    = require('./middleware')
 var Utils         = require('./utils')
@@ -33,6 +34,14 @@ module.exports = function(config, auth, storage) {
   //app.use(auth.bearer_middleware())
   app.use(expressJson5({ strict: false, limit: config.max_body_size || '10mb' }))
   app.use(Middleware.anti_loop(config))
+
+  // custom middleware
+  var custom_middleware = load_plugins(config, config.middleware, {}, function () {
+    return true
+  })
+  for (var i=0; i<custom_middleware.length; i++) {
+    app.use(custom_middleware)
+  }
 
   // for "npm whoami"
   app.get('/whoami', function(req, res, next) {
@@ -398,4 +407,3 @@ module.exports = function(config, auth, storage) {
 
   return app
 }
-


### PR DESCRIPTION
Adding the ability to load in custom middleware.

I need a way to restrict which npm client versions can access Sinopia, and the only way to do that is to inspect the request headers.  (See https://github.com/rlidwka/sinopia/issues/187)

I'm adding this middleware loader as a generic way for the Sinopia administrator to hook into api requests by adding middleware. The middleware will be specified in the `middleware` config.yaml key.

For now, I've set the `sanity_check` function to just return `true`, but I'm open to other ideas.
