### PR TITLE
Update fs-ext to 0.4.5 for iojs 2.0 compatibility.

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -311,10 +311,10 @@
       }
     },
     "fs-ext": {
-      "version": "0.4.4",
+      "version": "0.4.5",
       "dependencies": {
         "nan": {
-          "version": "1.6.2"
+          "version": "1.8.4"
         }
       }
     },


### PR DESCRIPTION
`fs-ext` 0.4.4 does not work with iojs 2.0 because it depends on an old version of `nan`.