### PR TITLE
Fix caching headers

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -474,6 +474,7 @@ Storage.prototype._sync_package_with_uplinks = function(name, pkginfo, options, 
     var _options = Object.assign({}, options)
     if (Utils.is_object(pkginfo._uplinks[up.upname])) {
       var fetched = pkginfo._uplinks[up.upname].fetched
+      _options.fetched = fetched
       if (fetched && fetched > (Date.now() - up.maxage)) {
         return cb()
       }

--- a/lib/up-storage.js
+++ b/lib/up-storage.js
@@ -251,8 +251,9 @@ Storage.prototype.get_package = function(name, options, callback) {
 
   var headers = {}
   if (options.etag) {
-    headers['If-None-Match'] = options.etag
-    headers['Accept']        = 'application/octet-stream'
+    headers['If-None-Match']     = options.etag
+    headers['If-Modified-Since'] = options.fetched
+    headers['Accept']            = 'application/octet-stream'
   }
 
   this.request({


### PR DESCRIPTION
This fixes the issue where new package versions come out, but were not
visible since sinopia was not invalidating it's cache after
the timeout
