### PR TITLE
Accept ^ and support ranges in package version requests

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -112,14 +112,14 @@ module.exports.get_version = function(object, version) {
 
   var found = undefined
   if(Semver.validRange(version)) {
-    for (var key in object.versions) {
+    for (var key in object.versions) {      
       var k = Semver.valid(key)
-      if (k && Semver.satisfies(k, version) && (!found || Semver.gt(k, found))) {
-        found = object.versions[key]
+      if (k && Semver.satisfies(k, version) && (!found || Semver.gt(k, Semver.valid(found)))) {
+        found = key
       }
     }
   }
-  return found
+  return object.versions[found]
 }
 
 module.exports.parse_address = function parse_address(addr) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -22,7 +22,7 @@ module.exports.validate_name = function(name) {
   name = name.toLowerCase()
 
   // all URL-safe characters and "@" for issue #75
-  if (!name.match(/^[-a-zA-Z0-9_.!~*'()@]+$/)
+  if (!name.match(/^[-a-zA-Z0-9_.!~*'()@^]+$/)
    || name.charAt(0) === '.' // ".bin", etc.
    || name.charAt(0) === '-' // "-" is reserved by couchdb
    || name === 'node_modules'
@@ -110,16 +110,16 @@ module.exports.tag_version = function(data, version, tag, config) {
 module.exports.get_version = function(object, version) {
   if (object.versions[version] != null) return object.versions[version]
 
-  try {
-    version = Semver.parse(version, true)
-    for (var k in object.versions) {
-      if (version.compare(Semver.parse(k, true)) === 0) {
-        return object.versions[k]
+  var found = undefined
+  if(Semver.validRange(version)) {
+    for (var key in object.versions) {
+      var k = Semver.valid(key)
+      if (k && Semver.satisfies(k, version) && (!found || Semver.gt(k, found))) {
+        found = object.versions[key]
       }
     }
-  } catch (err) {
-    return undefined
   }
+  return found
 }
 
 module.exports.parse_address = function parse_address(addr) {


### PR DESCRIPTION
I tested this out locally but I didn't run it through a full battery of tests that you might. It successfully accepts requests in the following forms:

```
http://myregistry.com/angular/^1.3.2
http://myregistry.com/angular/1.3.2
```

I removed the try/catch from the version getting function because proper checking is done I believe it shouldn't ever throw. It seems like the throwing was happening in `version.compare(...)` when version was `undefined`, which shouldn't ever happen in the below code.
