### PR TITLE
plugins: allow custom middlewares

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -14,7 +14,9 @@ function Auth(config) {
 
   var plugin_params = {
     config: config,
-    logger: self.logger
+    logger: self.logger,
+    AuthenticatedUser: AuthenticatedUser,
+    AnonymousUser: AnonymousUser
   }
 
   if (config.users_file) {
@@ -26,7 +28,7 @@ function Auth(config) {
   }
 
   self.plugins = load_plugins(config, config.auth, plugin_params, function (p) {
-    return p.authenticate || p.allow_access || p.allow_publish
+    return p.authenticate || p.allow_access || p.allow_publish || p.middleware
   })
 
   self.plugins.unshift({
@@ -305,6 +307,28 @@ Auth.prototype.cookie_middleware = function() {
       }
     })
   }
+}
+
+Auth.prototype.plugin_middlewares = function() {
+  return this.plugins.filter(function(p) {
+    return typeof p.middleware === 'function'
+  }).map(function(p) {
+    var handler = p.middleware()
+    return function(req, res, next) {
+      req.pause()
+      handler(req, res, function(err, user) {
+        req.resume()
+
+        if (err)
+          return next(err)
+
+        if (user)
+          req.remote_user = user
+
+        next()
+      })
+    }
+  })
 }
 
 Auth.prototype.issue_token = function(user) {

--- a/lib/index-api.js
+++ b/lib/index-api.js
@@ -28,6 +28,8 @@ module.exports = function(config, auth, storage) {
   app.param('org_couchdb_user', match(/^org\.couchdb\.user:/))
   app.param('anything',         match(/.*/))
 
+  var plugin_middlewares = auth.plugin_middlewares()
+  if (plugin_middlewares.length) app.use(plugin_middlewares)
   app.use(auth.basic_middleware())
   //app.use(auth.bearer_middleware())
   app.use(expressJson5({ strict: false, limit: config.max_body_size || '10mb' }))


### PR DESCRIPTION
This allows you to implement custom authentication flows which is not
username/password related. Eg. it let you implement authentication based
on remote ip address.

I've just added it for the api routes. Maybe the method, to be implemented in the plugins, should be named `middleware_api` and `middleware_web`?
