### PR TITLE
Refreshing the LocalData list and Search index for the shared FS based 'cluster' setup.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -40,6 +40,11 @@ function Config(config) {
       '.sinopia-db.json'
     )
   )
+  self.localList.on('data', function(data) {
+    if (data && data.secret) {
+      self.secret = data.secret
+    }
+  })
   if (!self.secret) {
     self.secret = self.localList.data.secret
 
@@ -195,4 +200,3 @@ module.exports.parse_interval = function(interval) {
   })
   return result
 }
-

--- a/lib/local-data.js
+++ b/lib/local-data.js
@@ -1,17 +1,37 @@
 var fs   = require('fs')
 var Path = require('path')
+var util = require("util")
+var events = require("events")
+var Logger    = require('./logger')
 
 module.exports = LocalData
 
 function LocalData(path) {
   var self = Object.create(LocalData.prototype)
+  events.EventEmitter.call(self);
+  self.logger = Logger.logger.child()
   self.path = path
-  try {
-    self.data = JSON.parse(fs.readFileSync(self.path, 'utf8'))
-  } catch(_) {
-    self.data = { list: [] }
-  }
+  self.parseData()
+  // Refreshes package list.
+  // Necessary in case of running Sinopia*
+  // in shared FS based 'cluster'.
+  fs.watchFile(self.path, function (curr, prev) {
+    self.parseData()
+  })
   return self
+}
+
+util.inherits(LocalData, events.EventEmitter)
+
+LocalData.prototype.parseData = function() {
+  try {
+    this.data = JSON.parse(fs.readFileSync(this.path, 'utf8'))
+    this.logger.warn('The LocalData config has been updated.')
+    this.emit("data", this.data)
+  } catch(err) {
+    this.logger.error({ err: err }, 'The LocalData config parse error: @{err.message}')
+    this.data = { list: [] }
+  }
 }
 
 LocalData.prototype.add = function(name) {
@@ -41,4 +61,3 @@ LocalData.prototype.sync = function() {
   } catch(err) {}
   fs.writeFileSync(this.path, JSON.stringify(this.data))
 }
-

--- a/lib/search.js
+++ b/lib/search.js
@@ -42,7 +42,10 @@ Search.prototype.reindex = function() {
 Search.prototype.configureStorage = function(storage) {
   this.storage = storage
   this.reindex()
+  var self = this
+  this.storage.config.localList.on('data', function(data) {
+    self.reindex()
+  })
 }
 
 module.exports = Search()
-


### PR DESCRIPTION
Hi,
the motivation of this change is as in the title.
We've set up 2 Sinopia nodes for the LB/Failover purpose, with the storage declared on the distributed, shared file system.
We've experienced that the second node does not reflect the initial publish changes in it's GUI (reflecting that at the API level though).
The attached patch corrects that. 
