### PR TITLE
add the ability to get a json list of all local packages

### DIFF
--- a/lib/index-web.js
+++ b/lib/index-web.js
@@ -40,30 +40,45 @@ module.exports = function(config, auth, storage) {
     Handlebars.registerPartial('entry', fs.readFileSync(require.resolve('./GUI/entry.hbs'), 'utf8'))
     var template = Handlebars.compile(fs.readFileSync(require.resolve('./GUI/index.hbs'), 'utf8'))
   }
-  app.get('/', function(req, res, next) {
-    var base = config.url_prefix
-             ? config.url_prefix.replace(/\/$/, '')
-             : req.protocol + '://' + req.get('host')
-    res.setHeader('Content-Type', 'text/html')
 
+  // returns an object of local packages
+  function get_library(user, cb) {
     storage.get_local(function(err, packages) {
       if (err) throw err // that function shouldn't produce any
       async.filterSeries(packages, function(package, cb) {
-        auth.allow_access(package.name, req.remote_user, function(err, allowed) {
+        auth.allow_access(package.name, user, function(err, allowed) {
           setImmediate(function () {
             cb(!err && allowed)
           })
         })
-      }, function(packages) {
-        next(template({
-          name:       config.web && config.web.title ? config.web.title : 'Sinopia',
-          packages:   packages,
-          baseUrl:    base,
-          username:   req.remote_user.name,
-        }))
-      })
+      }, cb);
     })
+  }
+
+  app.get('/-/library', function(req, res, next) {
+      get_library(req.remote_user, function(packages) {
+        next(packages);
+      });
+  });
+
+  app.get('/', function(req, res, next) {
+    var base = config.url_prefix
+             ? config.url_prefix.replace(/\/$/, '')
+             : req.protocol + '://' + req.get('host')
+
+    res.setHeader('Content-Type', 'text/html')
+
+    get_library(req.remote_user, function(packages) {
+      next(template({
+        name:       config.web && config.web.title ? config.web.title : 'Sinopia',
+        packages:   packages,
+        baseUrl:    base,
+        username:   req.remote_user.name,
+      }));
+    });
+
   })
+
 
   // Static
   app.get('/-/static/:filename', function(req, res, next) {
@@ -143,4 +158,3 @@ module.exports = function(config, auth, storage) {
   })
   return app
 }
-


### PR DESCRIPTION
Originally the '/' path returned an html that displays the list of all the local packages.
I splitted the functionality of getting the list of local packages and returning the html into two functions.
The root path '/' still behaves as before but now there is a new path '/-/library/' that returns a json of all local packages. Both paths use the same function to get the data.