### PR TITLE
Make integration tests work with npm@3

### DIFF
--- a/test/integration/test.pl
+++ b/test/integration/test.pl
@@ -8,6 +8,7 @@ use Cwd 'abs_path';
 use File::Basename;
 $ENV{HOME} = dirname(abs_path( __FILE__ )) . '/.sinopia_test_env';
 system('rm -rf .sinopia_test_env ; mkdir .sinopia_test_env') and quit('fail');
+system('echo \'{"name":"sinopia_test_env"}\' >.sinopia_test_env/package.json') and quit('fail');
 chdir $ENV{HOME};
 
 use Data::Dumper;
@@ -47,4 +48,3 @@ quit("
 ==================================================================
 All tests seem to be executed successfully, nothing is broken yet.
 ==================================================================");
-


### PR DESCRIPTION
npm@3 fails because it apparently tries to name the default package in the test directory ".sinopia_test_env", which is illegal. This creates a `package.json` with a valid name.
