### PR TITLE
Fix for positional argument not being case sensitive.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -42,7 +42,7 @@ module.exports.is_object = function(obj) {
 
 module.exports.validate_metadata = function(object, name) {
   assert(module.exports.is_object(object), 'not a json object')
-  assert.equal(object.name, name)
+  assert.equal(object.name.toLowerCase(), name.toLowerCase())
 
   if (!module.exports.is_object(object['dist-tags'])) {
     object['dist-tags'] = {}


### PR DESCRIPTION
Whilst uploading some mirrored packages, we came across some problems due to capitalization. It appears that the app does a compare of the object name (case sensitive) with the route parameter name (case insensitive), and thus will fail if packages have capital letters in their name.

The offending packages that raised the problem:
JSONStream
Base64

I have relaxed the check to be case insensitive, which seems to have fixed the problem.
