### PR TITLE
Permissions error opening a log file is swallowed because of an error

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -40,7 +40,7 @@ module.exports.setup = function(logs) {
     } else if (target.type === 'file') {
       var dest = require('fs').createWriteStream(target.path, {flags: 'a', encoding: 'utf8'})
       dest.on('error', function (err) {
-        Logger.emit('error', err)
+        logger.emit('error', err)
       })
       stream.write = function(obj) {
         if (target.format === 'pretty') {


### PR DESCRIPTION
Dont emit on Logger constructor, because it doesnt have that method

Causes an error of 'undefined is not a function' in the log instead of the actual error (i also have a console logger, which is where i saw the error)
