### PR TITLE
Endpoint for privately published modules

### DIFF
--- a/lib/index-web.js
+++ b/lib/index-web.js
@@ -74,6 +74,23 @@ module.exports = function(config, auth, storage) {
     })
   })
 
+  app.get('/-/private-modules', function(req, res, next) {
+    res.write('{"_updated":' + Date.now());
+    storage.get_local(function(err, packages) {
+      if (err) throw err // that function shouldn't produce any
+      async.filterSeries(packages, function(package, cb) {
+        res.write(',\n' + JSON.stringify(package.name) + ':' + JSON.stringify(package))
+        auth.allow_access(package.name, req.remote_user, function(err, allowed) {
+          setImmediate(function () {
+            cb(!err && allowed)
+          })
+        })
+      }, function(packages) {
+        res.end('}\n')
+      })
+    })
+  })
+
   // Static
   app.get('/-/static/:filename', function(req, res, next) {
     var file = __dirname + '/static/' + req.params.filename


### PR DESCRIPTION
Currently, there is no endpoint to retrieve only the private packages published. I believe it might be useful to expand your API to accommodate such a request. 
