### PR TITLE
Fixed: Could not login with existing user.

### DIFF
--- a/lib/index-api.js
+++ b/lib/index-api.js
@@ -180,23 +180,36 @@ module.exports = function(config, auth, storage) {
           return next( Error[422]('user/password is not found in request (npm issue?)') )
         }
       }
-      auth.add_user(req.body.name, req.body.password, function(err, user) {
-        if (err) {
-          if (err.status >= 400 && err.status < 500) {
-            // With npm registering is the same as logging in,
-            // and npm accepts only an 409 error.
-            // So, changing status code here.
-            return next( Error[409](err.message) )
-          }
-          return next(err)
+      // try to login first
+      auth.authenticate(req.body.name, req.body.password, function (err, user) {
+        if (!err) {
+          // user already exists, login
+          req.remote_user = user
+          res.status(201)
+          return next({
+            ok: "you are authenticated as '" + req.body.name + "'",
+            token: token,
+          })
         }
+        // could not login, try to create user
+        auth.add_user(req.body.name, req.body.password, function(err, user) {
+          if (err) {
+            if (err.status >= 400 && err.status < 500) {
+              // With npm registering is the same as logging in,
+              // and npm accepts only an 409 error.
+              // So, changing status code here.
+              return next( Error[409](err.message) )
+            }
+            return next(err)
+          }
 
-        req.remote_user = user
-        res.status(201)
-        return next({
-          ok: "user '" + req.body.name + "' created",
-          //token: auth.issue_token(req.remote_user),
-          token: token,
+          req.remote_user = user
+          res.status(201)
+          return next({
+            ok: "user '" + req.body.name + "' created",
+            //token: auth.issue_token(req.remote_user),
+            token: token,
+          })
         })
       })
     }


### PR DESCRIPTION
PUT /-/user/:org_couchdb_user should login with existing user when password matches the username, added auth.authenticate call before auth.add_user.

Login with existing user did not work:
https://github.com/rlidwka/sinopia/issues/329

But the expected behavior is to log in the user in the first PUT request.
See this fiddler request log taken from registry.npmjs.org:

Request:

```
PUT http://registry.npmjs.org/-/user/org.couchdb.user:test HTTP/1.1
accept-encoding: gzip
version: 2.14.4
accept: application/json
referer: adduser
npm-session: ***
user-agent: npm/2.14.4 node/v4.1.1 win32 x64
host: registry.npmjs.org
content-type: application/json
content-length: 156
Connection: keep-alive

{"_id":"org.couchdb.user:test","name":"test","password":"abc","email":"email@test.com","type":"user","roles":[],"date":"2015-10-23T20:33:54.862Z"}
```

Response: (registry.npmjs.org)

```
HTTP/1.1 201 Created
Content-Type: application/json
Cache-Control: max-age=60
Content-Length: 127
Accept-Ranges: bytes
Date: Fri, 23 Oct 2015 20:33:56 GMT
Via: 1.1 varnish
Connection: keep-alive
X-Served-By: cache-fra1227-FRA
X-Cache: MISS
X-Cache-Hits: 0
X-Timer: S1445632435.244664,VS0,VE781

{"ok":true,"id":"org.couchdb.user:undefined","rev":"_we_dont_use_revs_any_more","token":"xyz"}
```

So as you can see the first PUT request should respond with 201 Created to log in the existing user.
