### PR TITLE
Config file path from env

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -50,6 +50,8 @@ var config, config_path
 try {
   if (commander.config) {
     config_path = Path.resolve(commander.config)
+  } else if (process.env.SINOPIA_CONFIG) {
+    config_path = Path.resolve(process.env.SINOPIA_CONFIG)
   } else {
     config_path = require('./config-path')()
   }


### PR DESCRIPTION
This PR allows to pass the config path through the `SINOPIA_CONFIG` environment variable. This can be useful when using process managers like PM2.
