### PR TITLE
ADDED intermediate ssl certificate option

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -131,7 +131,9 @@ function afterConfigLoad() {
           secureProtocol: 'SSLv23_method', // disable insecure SSLv2 and SSLv3
           secureOptions: constants.SSL_OP_NO_SSLv2 | constants.SSL_OP_NO_SSLv3,
           key: fs.readFileSync(config.https.key),
-          cert: fs.readFileSync(config.https.cert)
+          cert: fs.readFileSync(config.https.cert),
+          ca: fs.readFileSync(config.https.ca)
+
         }, app)
       } catch (err) { // catch errors related to certificate loading
         logger.logger.fatal({ err: err }, 'cannot create server: @{err.message}')

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -133,7 +133,6 @@ function afterConfigLoad() {
           key: fs.readFileSync(config.https.key),
           cert: fs.readFileSync(config.https.cert),
           ca: fs.readFileSync(config.https.ca)
-
         }, app)
       } catch (err) { // catch errors related to certificate loading
         logger.logger.fatal({ err: err }, 'cannot create server: @{err.message}')


### PR DESCRIPTION
The https module allows for an intermediate certificate in the options.
It was somehow missed. Adding it back since I had a certificate that
included an intermediate certificate.
