### PR TITLE
Issue #381 fix

### DIFF
--- a/lib/index-web.js
+++ b/lib/index-web.js
@@ -7,6 +7,7 @@ var Handlebars    = require('handlebars')
 var renderReadme  = require('render-readme')
 var Search        = require('./search')
 var Middleware    = require('./middleware')
+var utils         = require('./utils')
 var match         = Middleware.match
 var validate_name = Middleware.validate_name
 var validate_pkg  = Middleware.validate_package
@@ -42,7 +43,7 @@ module.exports = function(config, auth, storage) {
   }
   app.get('/', function(req, res, next) {
     var base = config.url_prefix
-             ? config.url_prefix.replace(/\/$/, '')
+             ? utils.buildUrlPrefix(config.url_prefix, req)
              : req.protocol + '://' + req.get('host')
     res.setHeader('Content-Type', 'text/html')
 
@@ -104,7 +105,7 @@ module.exports = function(config, auth, storage) {
       }
 
       var base = config.url_prefix
-               ? config.url_prefix.replace(/\/$/, '')
+               ? utils.buildUrlPrefix(config.url_prefix, req)
                : req.protocol + '://' + req.get('host')
       res.redirect(base)
     })
@@ -112,7 +113,7 @@ module.exports = function(config, auth, storage) {
 
   app.post('/-/logout', function(req, res, next) {
     var base = config.url_prefix
-             ? config.url_prefix.replace(/\/$/, '')
+             ? utils.buildUrlPrefix(config.url_prefix, req)
              : req.protocol + '://' + req.get('host')
     res.cookies.set('token', '')
     res.redirect(base)

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,6 +20,9 @@ module.exports = function(config_hash) {
   // it shouldn't make any difference anyway
   app.set('env', process.env.NODE_ENV || 'production')
 
+  // use x-forwarded-for if present
+  app.enable('trust proxy');
+
   function error_reporting_middleware(req, res, next) {
     res.report_error = res.report_error || function(err) {
       if (err.status && err.status >= 400 && err.status < 600) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -62,7 +62,7 @@ module.exports.filter_tarball_urls = function(pkg, req, config) {
     var filename = URL.parse(_url).pathname.replace(/^.*\//, '')
 
     if (config.url_prefix != null) {
-      var result = config.url_prefix.replace(/\/$/, '')
+      var result = buildUrlPrefix(config.url_prefix, req);
     } else {
       var result = req.protocol + '://' + req.headers.host
     }
@@ -78,6 +78,15 @@ module.exports.filter_tarball_urls = function(pkg, req, config) {
     }
   }
   return pkg
+}
+
+module.exports.buildUrlPrefix = buildUrlPrefix;
+
+function buildUrlPrefix(url_prefix, req){
+  var result = url_prefix.replace(/\/$/, '')
+  result = result.replace(/\${scheme}/,req.protocol);
+  result = result.replace(/\${host}/,req.hostname);
+  result = result.replace(/\${port}/,req.port);
 }
 
 function can_add_tag(tag, config) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -85,8 +85,7 @@ module.exports.buildUrlPrefix = buildUrlPrefix;
 function buildUrlPrefix(url_prefix, req){
   var result = url_prefix.replace(/\/$/, '');
   result = result.replace(/\${scheme}/,req.protocol);
-  result = result.replace(/\${host}/,req.hostname);
-  result = result.replace(/\${port}/,req.port);
+  result = result.replace(/\${host}/,req.get('host'));
 }
 
 function can_add_tag(tag, config) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -83,7 +83,7 @@ module.exports.filter_tarball_urls = function(pkg, req, config) {
 module.exports.buildUrlPrefix = buildUrlPrefix;
 
 function buildUrlPrefix(url_prefix, req){
-  var result = url_prefix.replace(/\/$/, '')
+  var result = url_prefix.replace(/\/$/, '');
   result = result.replace(/\${scheme}/,req.protocol);
   result = result.replace(/\${host}/,req.hostname);
   result = result.replace(/\${port}/,req.port);


### PR DESCRIPTION
Now it is possible to use two different variables in url_prefix:
- **${scheme}**: this variable it will be dinamically replaced with the value of [`req.protocol`](http://expressjs.com/en/4x/api.html#req.protocol)
- **${host}**: this variable it will be dinamically replaced with the value of `req.get('host')` which includes the host and port included in `x-forwarded-for` header or `host` header.

All tests are passing.
