### PR TITLE
makes middlewares pluggable. i.e for custom oauth flows or analytics etc.

### DIFF
--- a/conf/full.yaml
+++ b/conf/full.yaml
@@ -125,3 +125,7 @@ logs:
 # and the highest semver is placed instead.
 #ignore_latest_tag: false
 
+# Configure plugins that can register custom middlewares
+#middlewares:
+# plugin-name:
+#   setting: true

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,7 @@ var Config        = require('./config')
 var Middleware    = require('./middleware')
 var Cats          = require('./status-cats')
 var Storage       = require('./storage')
+var load_plugins  = require('./plugin-loader').load_plugins
 
 module.exports = function(config_hash) {
   Logger.setup(config_hash.logs)
@@ -72,6 +73,18 @@ module.exports = function(config_hash) {
       })
     })
   }
+
+  // register middleware plugins
+  var plugin_params = {
+    config: config,
+    logger: Logger.logger
+  };
+  var plugins = load_plugins(config, config.middlewares, plugin_params, function (p) {
+    return p.register_middlewares
+  })
+  plugins.forEach(function(p) {
+    p.register_middlewares(app, auth, storage);
+  });
 
   app.use(require('./index-api')(config, auth, storage))
 

--- a/test/functional/config-2.yaml
+++ b/test/functional/config-2.yaml
@@ -14,6 +14,10 @@ uplinks:
 web:
   enable: true
 
+middlewares:
+  ./plugins/middlewares:
+    message: this is a custom route
+
 auth:
   ./plugins/authenticate:
     accept_user: authtest2

--- a/test/functional/plugins.js
+++ b/test/functional/plugins.js
@@ -5,6 +5,17 @@ var assert = require('assert')
 module.exports = function() {
   var server2 = process.server2
 
+  describe('middlewares', function() {
+    it('should serve the registered route', function() {
+      return server2.request({
+        uri: '/test/route',
+        method: 'GET'
+      })
+      .status(200)
+      .body_ok('this is a custom route')
+    })
+  })
+
   describe('authentication', function() {
     var authstr
 

--- a/test/functional/plugins/middlewares.js
+++ b/test/functional/plugins/middlewares.js
@@ -1,0 +1,17 @@
+
+module.exports = Plugin
+
+function Plugin(config, stuff) {
+  var self = Object.create(Plugin.prototype)
+  self._config = config
+  return self
+}
+
+Plugin.prototype.register_middlewares = function(app, auth, storage) {
+  var message = this._config.message
+
+  app.get('/test/route', function(req, res, next) {
+    res.status(200)
+    return next({ ok: message })
+  });
+}


### PR DESCRIPTION
I'm building a github web oauth authorization plugin for sinopia. To achieve that in a good way I need to be able to register custom routes in sinopia, so that I don't have to have github or sinopia secrets on my client to be able to generate a .npmrc
