### PR TITLE
Fixed scope packages

### DIFF
--- a/lib/up-storage.js
+++ b/lib/up-storage.js
@@ -261,7 +261,7 @@ Storage.prototype.get_package = function(name, options, callback) {
   }
 
   this.request({
-    uri     : '/' + encode(name),
+    uri     : '/' + name.split('/').join(encode('/')),
     json    : true,
     headers : headers,
     req     : options.req,


### PR DESCRIPTION
This function 'encode(name)' encoded whole name.
If package is scope like babel (@babel/babel-cli) there is a problem with @ character.
url have to be 'npm_repo_url'/@babel%2fbabel-cli but with 'encode(name)' we get  'npm_repo_url'/%40babel%2fbabel-cli 